### PR TITLE
Update dependencies and change namespace to standard

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,7 +1,7 @@
 (set-env!
  :source-paths   #{"src"}
  :resource-paths #{"src" "resources"}
- :dependencies '[[org.clojure/clojure "1.9.0" :scope "provided"]
+ :dependencies '[[org.clojure/clojure "1.10.1" :scope "provided"]
                  [clj-http "3.9.1"]
                  [cheshire "5.8.1"]
                  [com.cemerick/url "0.1.1"]
@@ -17,10 +17,10 @@
 (require '[adzerk.boot-test :as t])
 
 (task-options!
- pom '{:project irresponsible/tentacles
-       :version "0.6.4-SNAPSHOT"
+ pom '{:project clj-commons/tentacles
+       :version "0.6.5-SNAPSHOT"
        :description "A library for working with the Github API."
-       :url "https://github.com/irresponsible/tentacles"
+       :url "https://github.com/clj-commons/tentacles"
        :license {"Eclipse Public License" "http://www.eclipse.org/legal/epl-v10.html"}}
  push {:tag true
        :ensure-branch "master"


### PR DESCRIPTION
# Description:

I know that this PR it might not be perfect but I just tried it to help. For any feedback feel free to write me here and i will adapt it :grin: 

# What does this PR:

- change ns to `clj-commons`
- update clojure dep
- update version to +1

# Left-over

Currenlty I don't know if this pr can impact also the release model.

I have seen that somehow the JAR and publication of it to clojars is kind automated by a 3rd party tool, which was hosted by the `irresponsible` user.

See also issue : https://github.com/clj-commons/tentacles/issues/16 which is kind related



