### PR TITLE
Fix keyword response handling & headers passing

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -58,20 +58,20 @@ You can access useful information returned by the API such as current
 rate limits, etags, etc. by checking the response with `core/api-meta`. You can then use this to perform conditional requests against the API. If the data has not changed, the keyword `:tentacles.core/not-modified` will be returned. This does not consume any API call quota. Please be aware that conditional requests won't work if :all-pages is set to true.
 
 ```clojure
-user> (core/api-meta (repos/readme "Raynes" "tentacles" {}))
+user> (core/api-meta (repos/readme "clj-commons" "tentacles" {}))
 {:links {nil nil}, :etag "\"f1f3cfabbf0f98e0bbaa7aa424f92e75\"", :last-modified "Mon, 28 Jan 2013 21:13:48 GMT", :call-limit 60, :call-remaining 59}
 
-user> (repos/readme "Raynes" "tentacles" {:etag "\"f1f3cfabbf0f98e0bbaa7aa424f92e75\""})
+user> (repos/readme "clj-commons" "tentacles" {:etag "\"f1f3cfabbf0f98e0bbaa7aa424f92e75\""})
 :tentacles.core/not-modified
 
-user> (repos/readme "Raynes" "tentacles" {:if-modified-since "Mon, 28 Jan 2013 21:13:48 GMT"})
+user> (repos/readme "clj-commons" "tentacles" {:if-modified-since "Mon, 28 Jan 2013 21:13:48 GMT"})
 :tentacles.core/not-modified
 ```
 
 Similarly, you can set an User-Agent to make your requests more friendly and identifiable.
 
 ```clojure
-user> (repos/readme "Raynes" "tentacles" {:user-agent "MyPhoneApp"})
+user> (repos/readme "clj-commons" "tentacles" {:user-agent "MyPhoneApp"})
 ```
 
 The Github API is massive and great. I can't demonstrate every API call. Everything is generally just as easy as the above examples, and I'm working hard to document things as well as possible, so go explore!

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -131,12 +131,21 @@
                               (safe-parse (http/request req)))
            exec-request (fn exec-request [req]
                           (let [resp (exec-request-one req)]
-                            (cond (and all-pages? (-> resp meta :links :next))
-                                  (let [new-req (update-req req (-> resp meta :links :next))]
-                                    (lazy-cat resp (exec-request new-req)))
-                                  (and (seq resp) (seq (first resp)))
-                                  resp
-                                  :else nil)))]
+                            (cond
+                              (keyword? resp)
+                              resp
+
+                              (and all-pages?
+                                   (-> resp meta :links :next))
+                              (let [new-req (update-req req (-> resp meta :links :next))]
+                                (lazy-cat resp (exec-request new-req)))
+
+                              (and (seq resp)
+                                   (seq (first resp)))
+                              resp
+
+                              :else
+                              nil)))]
        (exec-request req))))
 
 (defn raw-api-call

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -13,6 +13,15 @@
       (is (contains? (:headers request) "User-Agent"))
       (is (= (get (:headers request) "User-Agent") "Mozilla")))))
 
+(deftest request-handle-multiple-headers
+  (let [request (core/make-request :get "test" nil {:user-agent "Mozilla"
+                                                    :etag "sample-etag"})]
+    (is (empty?    (:query-params request)))
+    (is (contains? (:headers request) "User-Agent"))
+    (is (contains? (:headers request) "If-None-Match"))
+    (is (= (get (:headers request) "User-Agent") "Mozilla"))
+    (is (= (get (:headers request) "If-None-Match") "sample-etag"))))
+
 (deftest request-contains-user-agent-from-defaults
   (core/with-defaults {:user-agent "Mozilla"}
     (let [request (core/make-request :get "test" nil {})]
@@ -24,7 +33,7 @@
 (deftest request-with-bearer-token
   (core/with-defaults {:bearer-token "test-token"}
     (let [request (core/make-request :get "test" nil {})]
-        (is (= (get (:headers request) "Authorization") "Bearer test-token")))))
+      (is (= (get (:headers request) "Authorization") "Bearer test-token")))))
 
 (deftest adhoc-options-override-defaults
   (core/with-defaults {:user-agent "default"}


### PR DESCRIPTION
## 1. Keyword response handling

`safe-parse` return keywords for some specific responses so the code within `api-call` needs to handle such case too.

This should fix #18 and restore the `:if-modified-since` feature.

## 2. Headers passing

`make-request` would only retain the last header given instead of concatenating all the data.