### PR TITLE
fix wrong api call

### DIFF
--- a/src/tentacles/issues.clj
+++ b/src/tentacles/issues.clj
@@ -114,9 +114,9 @@
 
 (defn create-comment
   "Create a comment."
-  [user repo id body options]
+  [user repo issue-number body options]
   (api-call :post "repos/%s/%s/issues/%s/comments"
-            [user repo id] (assoc options :body body)))
+            [user repo issue-number] (assoc options :body body)))
 
 (defn edit-comment
   "Edit a comment."


### PR DESCRIPTION
It is not a real issue but the arg name is wrong
`repos/:owner/:repo/issues/:issue_number/comments`

https://developer.github.com/v3/issues/comments/#create-a-comment