### PR TITLE
Add support for socket and conn timeout

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -95,7 +95,7 @@
 (defn make-request [method end-point positional query]
   (let [{:keys [auth throw-exceptions follow-redirects accept
                 oauth-token etag if-modified-since user-agent
-                otp bearer-token]
+                otp bearer-token conn-timeout socket-timeout]
          :or {follow-redirects true throw-exceptions false}
          :as query} (merge defaults query)
         headers (cond-> {}
@@ -128,11 +128,18 @@
                      :method method}
 
               (seq headers)
-              (assoc :headers headers))
+              (assoc :headers headers)
+
+              conn-timeout
+              (assoc :conn-timeout conn-timeout)
+
+              socket-timeout
+              (assoc :socket-timeout socket-timeout))
         raw-query (:raw query)
         proper-query (query-map (dissoc query :auth :oauth-token :all-pages
                                         :accept :user-agent :otp
-                                        :etag :if-modified-since))
+                                        :etag :if-modified-since
+                                        :throw-exceptions :conn-timeout :socket-timeout))
         req (if (#{:post :put :delete :patch} method)
               (assoc req :body (json/generate-string (or raw-query proper-query)))
               (assoc req :query-params proper-query))]

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -57,3 +57,16 @@
                              (core/safe-parse {:status 200
                                                :headers {"x-poll-interval" "61"
                                                          "content-type" "application/json"}}))))))
+
+(deftest request-allows-conn-and-socket-timeouts
+  (let [request (core/make-request :get "test" nil {})]
+    (is (nil? (:conn-timeout request)))
+    (is (nil? (:socket-timeout request))))
+
+  (let [request (core/make-request :get "test" nil {:socket-timeout 5000
+                                                    :conn-timeout 5000})]
+    (def request request)
+    (is (nil? (-> request :query-params (get "socket_timeout"))))
+    (is (nil? (-> request :query-params (get "conn_timeout"))))
+    (is (= 5000 (:conn-timeout request)))
+    (is (= 5000 (:socket-timeout request)))))


### PR DESCRIPTION
I've noticed quite a few connection timeout errors from github recently
and waiting the default 2 minutes for a connection failure slows things
down a lot.

This allows us to pass socket-timeout and conn-timeout into the query in
the same manner as :throw-exceptions. These are passed to clj-http and
give control over these settings.