### PR TITLE
Fix http method missing bug

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -125,9 +125,9 @@
              (conj {:url (format-url end-point positional)
                     :basic-auth auth
                     :throw-exceptions throw-exceptions
-                    :follow-redirects follow-redirects}
-                   (select-keys query [:method
-                                       :socket-timeout
+                    :follow-redirects follow-redirects
+                    :method method}
+                   (select-keys query [:socket-timeout
                                        :conn-timeout ; conn-timeout is deprecated - see https://github.com/dakrone/clj-http/issues/477
                                        :connection-timeout]))
 

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -58,6 +58,10 @@
                                                :headers {"x-poll-interval" "61"
                                                          "content-type" "application/json"}}))))))
 
+(deftest http-method-is-set 
+  (let [request (core/make-request :get "test" nil {})]
+    (is (= :get (:method request)))))
+
 (deftest request-allows-conn-and-socket-timeouts
   (let [request (core/make-request :get "test" nil {})]
     (is (nil? (:connection-timeout request)))
@@ -67,7 +71,6 @@
   (let [request (core/make-request :get "test" nil {:socket-timeout 5000
                                                     :connection-timeout 3000
                                                     :conn-timeout 5000})]
-    (def request request)
     (is (nil? (-> request :query-params (get "socket_timeout"))))
     (is (nil? (-> request :query-params (get "connection_timeout"))))
     (is (nil? (-> request :query-params (get "conn_timeout"))))


### PR DESCRIPTION
Looks like the last refactor had a typo and it started pulling the HTTP
method from the query map rather than the function parameter.

I think the last release was fairly broken due to this. Simple fix
though.